### PR TITLE
Preethy feature/level2-docker-dockercompose-jenkins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,5 @@ RUN mvn clean install
 FROM maven:3.9.6-eclipse-temurin-17
 WORKDIR /app
 COPY --from=build /app .
-CMD ["mvn", "test", "-DsuiteXmlFile=testng.xml"]
+ENV TEST_ENV=qa
+CMD ["mvn", "test", "-DsuiteXmlFile=testng.xml", "-Denv=${TEST_ENV}"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN mvn clean install
 FROM maven:3.9.6-eclipse-temurin-17
 WORKDIR /app
 COPY --from=build /app .
-CMD ["mvn", "test", "-Dtest=runner.CucumberTest"]
+CMD ["mvn", "test", "-DsuiteXmlFile=testng.xml"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,17 +20,6 @@ pipeline {
             }
         }
 
-        stage('Run Tests in Docker') {
-            when {
-                expression { false } // Disable this stage; use Docker Compose instead
-            }
-            steps {
-                script {
-                    sh "docker run --rm -v $WORKSPACE/target:/app/target $DOCKER_IMAGE"
-                }
-            }
-        }
-
         stage('Run Tests with Docker Compose') {
             steps {
                 script {

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ This framework supports rerunning only failed Cucumber scenarios using the Cucum
 ### Example Workflow
 1. Run all scenarios:
    ```sh
-   mvn test -Dtest=runner.CucumberTest
+   mvn test -Dtest=runner.CreateEmployeeCucumberTest
    ```
 2. If there are failures, rerun only failed scenarios:
    ```sh

--- a/README.md
+++ b/README.md
@@ -94,29 +94,42 @@ base.url=http://localhost:9090
 
 ## Running with Docker
 
-You can build and run your tests in a containerized environment using Docker:
+You can build and run your tests in a containerized environment using Docker. By default, the QA environment is used.
 
 - **Build the Docker image:**
   ```sh
   docker build -t api-automation-tests .
   ```
-- **Run the tests in a container:**
+- **Run the tests in a container (QA by default):**
   ```sh
   docker run --rm -v $(pwd)/target:/app/target api-automation-tests
   ```
+- **Override the environment at runtime (e.g., for DEV):**
+  ```sh
+  docker run --rm -e TEST_ENV=dev -v $(pwd)/target:/app/target api-automation-tests
+  ```
 - The test reports will be available in your local `target/` directory after the run.
+
+## Running with Docker Compose
+
+By default, Docker Compose uses the QA environment. To run with a different environment, override `TEST_ENV` at runtime:
+
+- **Run with QA (default):**
+  ```sh
+  docker-compose up --abort-on-container-exit
+  ```
+- **Run with DEV:**
+  ```sh
+  TEST_ENV=dev docker-compose up --abort-on-container-exit
+  ```
 
 ## Environment-Specific Test Data
 
 - Test data is organized by environment:
   - `src/test/resources/testdata/dev/employees.csv`
   - `src/test/resources/testdata/qa/employees.csv`
-- The environment is set in `src/test/resources/config.properties` via the `env` property (e.g., `env=dev`).
-- You can override the environment at runtime:
-  ```sh
-  mvn test -Denv=qa
-  ```
-- Step definitions automatically load the correct test data for the selected environment.
+- The environment is set in `src/test/resources/config.properties` via the `env` property (e.g., `env=dev`), but is typically overridden at runtime using the `-Denv` system property (set by Docker/Compose as `TEST_ENV`).
+- You can override the environment at runtime as shown above.
 
 ## Retrying Failed Scenarios (Cucumber Rerun)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - wiremock
     environment:
       - BASE_URL=http://wiremock:8080
+      - TEST_ENV=qa
     volumes:
       - ./target:/app/target
-    command: mvn test -DsuiteXmlFile=testng.xml
+    command: mvn test -DsuiteXmlFile=testng.xml -Denv=${TEST_ENV}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,5 +15,4 @@ services:
       - BASE_URL=http://wiremock:8080
     volumes:
       - ./target:/app/target
-    command: mvn test -Dtest=runner.CucumberTest
-
+    command: mvn test -DsuiteXmlFile=testng.xml

--- a/src/test/java/config/TestConfig.java
+++ b/src/test/java/config/TestConfig.java
@@ -65,25 +65,21 @@ public class TestConfig {
     }
 
     public static String getEmployeesTestDataPath() {
-        String env = properties.getProperty("env", "dev");
+        String env = getEnv(); // Use dynamic env selection
         String value = properties.getProperty("testdata.employees");
         if (value == null || value.isEmpty()) {
             log.error("Property testdata.employees not found or empty");
             throw new IllegalStateException("Property testdata.employees not found or empty");
         }
-
         if (env == null || env.isEmpty()) {
             log.warn("Environment not specified, using default 'dev'");
             env = "dev";
         }
-
         log.info("Using environment: {}", env);
-
         if (value.startsWith("testdata/" + env + "/")) {
             log.info("testdata.employees path is already environment-specific: {}", value);
             return value;
         }
-
         String fileName = value.substring(value.lastIndexOf('/') + 1);
         String fullPath = String.join("/", "testdata", env, fileName);
         log.info("Computed environment-specific testdata.employees path: {}", fullPath);
@@ -99,5 +95,17 @@ public class TestConfig {
         int port = Integer.parseInt(value);
         log.info("wiremock.port: {}", port);
         return port;
+    }
+
+    public static String getEnv() {
+        String env = System.getProperty("env");
+        if (env != null && !env.isEmpty()) {
+            log.info("Using environment from system property: {}", env);
+            return env;
+        }
+        // Fallback to config.properties
+        env = properties.getProperty("env", "dev");
+        log.info("Using environment from config.properties: {}", env);
+        return env;
     }
 }

--- a/src/test/java/runner/CreateEmployeeCucumberTest.java
+++ b/src/test/java/runner/CreateEmployeeCucumberTest.java
@@ -1,0 +1,39 @@
+package runner;
+
+import io.cucumber.testng.AbstractTestNGCucumberTests;
+import io.cucumber.testng.CucumberOptions;
+import mocks.WireMockServerSetup;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+
+@CucumberOptions(
+    features = "src/test/java/features/CreateEmployee.feature",
+    glue = {"stepdefs"},
+    plugin = {"pretty", "summary", "html:target/cucumber-report.html", "json:target/cucumber-report.json", "rerun:target/rerun.txt"}
+)
+public class CreateEmployeeCucumberTest extends AbstractTestNGCucumberTests {
+    @BeforeClass
+    public void setUp() {
+        // Only start WireMock if not running under Docker Compose (i.e., if USE_EXTERNAL_WIREMOCK is not set to true)
+        String useExternalWireMock = System.getenv("USE_EXTERNAL_WIREMOCK");
+        if (useExternalWireMock == null || !useExternalWireMock.equalsIgnoreCase("true")) {
+            WireMockServerSetup.startServer();
+        }
+    }
+
+    @AfterClass
+    public void tearDown() {
+        // Only stop WireMock if it was started by this process
+        String useExternalWireMock = System.getenv("USE_EXTERNAL_WIREMOCK");
+        if (useExternalWireMock == null || !useExternalWireMock.equalsIgnoreCase("true")) {
+            WireMockServerSetup.stopServer();
+        }
+    }
+
+    @Override
+    @DataProvider(parallel = true)
+    public Object[][] scenarios() {
+        return super.scenarios();
+    }
+}

--- a/src/test/java/runner/DeleteEmployeeCucumberTest.java
+++ b/src/test/java/runner/DeleteEmployeeCucumberTest.java
@@ -1,0 +1,39 @@
+package runner;
+
+import io.cucumber.testng.AbstractTestNGCucumberTests;
+import io.cucumber.testng.CucumberOptions;
+import mocks.WireMockServerSetup;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+
+@CucumberOptions(
+    features = "src/test/java/features/DeleteEmployee.feature",
+    glue = {"stepdefs"},
+    plugin = {"pretty", "summary", "html:target/cucumber-report.html", "json:target/cucumber-report.json", "rerun:target/rerun.txt"}
+)
+public class DeleteEmployeeCucumberTest extends AbstractTestNGCucumberTests {
+    @BeforeClass
+    public void setUp() {
+        // Only start WireMock if not running under Docker Compose (i.e., if USE_EXTERNAL_WIREMOCK is not set to true)
+        String useExternalWireMock = System.getenv("USE_EXTERNAL_WIREMOCK");
+        if (useExternalWireMock == null || !useExternalWireMock.equalsIgnoreCase("true")) {
+            WireMockServerSetup.startServer();
+        }
+    }
+
+    @AfterClass
+    public void tearDown() {
+        // Only stop WireMock if it was started by this process
+        String useExternalWireMock = System.getenv("USE_EXTERNAL_WIREMOCK");
+        if (useExternalWireMock == null || !useExternalWireMock.equalsIgnoreCase("true")) {
+            WireMockServerSetup.stopServer();
+        }
+    }
+
+    @Override
+    @DataProvider(parallel = true)
+    public Object[][] scenarios() {
+        return super.scenarios();
+    }
+}

--- a/src/test/java/runner/ReadEmployeeCucumberTest.java
+++ b/src/test/java/runner/ReadEmployeeCucumberTest.java
@@ -1,0 +1,39 @@
+package runner;
+
+import io.cucumber.testng.AbstractTestNGCucumberTests;
+import io.cucumber.testng.CucumberOptions;
+import mocks.WireMockServerSetup;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+
+@CucumberOptions(
+    features = "src/test/java/features/ReadEmployee.feature",
+    glue = {"stepdefs"},
+    plugin = {"pretty", "summary", "html:target/cucumber-report.html", "json:target/cucumber-report.json", "rerun:target/rerun.txt"}
+)
+public class ReadEmployeeCucumberTest extends AbstractTestNGCucumberTests {
+    @BeforeClass
+    public void setUp() {
+        // Only start WireMock if not running under Docker Compose (i.e., if USE_EXTERNAL_WIREMOCK is not set to true)
+        String useExternalWireMock = System.getenv("USE_EXTERNAL_WIREMOCK");
+        if (useExternalWireMock == null || !useExternalWireMock.equalsIgnoreCase("true")) {
+            WireMockServerSetup.startServer();
+        }
+    }
+
+    @AfterClass
+    public void tearDown() {
+        // Only stop WireMock if it was started by this process
+        String useExternalWireMock = System.getenv("USE_EXTERNAL_WIREMOCK");
+        if (useExternalWireMock == null || !useExternalWireMock.equalsIgnoreCase("true")) {
+            WireMockServerSetup.stopServer();
+        }
+    }
+
+    @Override
+    @DataProvider(parallel = true)
+    public Object[][] scenarios() {
+        return super.scenarios();
+    }
+}

--- a/src/test/java/runner/UpdateEmployeeCucumberTest.java
+++ b/src/test/java/runner/UpdateEmployeeCucumberTest.java
@@ -8,11 +8,11 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 
 @CucumberOptions(
-    features = "src/test/java/features",
+    features = "src/test/java/features/UpdateEmployee.feature",
     glue = {"stepdefs"},
     plugin = {"pretty", "summary", "html:target/cucumber-report.html", "json:target/cucumber-report.json", "rerun:target/rerun.txt"}
 )
-public class CucumberTest extends AbstractTestNGCucumberTests {
+public class UpdateEmployeeCucumberTest extends AbstractTestNGCucumberTests {
     @BeforeClass
     public void setUp() {
         // Only start WireMock if not running under Docker Compose (i.e., if USE_EXTERNAL_WIREMOCK is not set to true)

--- a/src/test/resources/config.properties
+++ b/src/test/resources/config.properties
@@ -2,7 +2,7 @@
 base.url=http://localhost:9090
 
 # Environment (dev, qa, prod)
-env=dev
+env=qa
 
 # Endpoints
 employees.endpoint=/employees

--- a/testng.xml
+++ b/testng.xml
@@ -3,7 +3,10 @@
 <suite name="APIAutomationSuite" parallel="classes" thread-count="4">
     <test name="CucumberTests">
         <classes>
-            <class name="runner.CucumberTest"/>
+            <class name="runner.CreateEmployeeCucumberTest"/>
+            <class name="runner.ReadEmployeeCucumberTest"/>
+            <class name="runner.UpdateEmployeeCucumberTest"/>
+            <class name="runner.DeleteEmployeeCucumberTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
This pull request introduces significant improvements to environment configuration and test runner structure for the API automation test framework. The main changes include enhanced environment selection (defaulting to QA), improved Docker and Docker Compose integration, and splitting the Cucumber test runner into separate classes for each feature. The documentation has also been updated to reflect these changes and provide clearer instructions for running tests in different environments.

**Environment and Configuration Improvements**
- Default test environment changed from `dev` to `qa`, both in `config.properties` and Docker-related files, with the ability to override using the `TEST_ENV` environment variable at runtime. The `TestConfig` class now uses a new `getEnv()` method to dynamically determine the environment, prioritizing the system property before falling back to the config file. [[1]](diffhunk://#diff-cad36c7f961963708e692cfa3f8f6b9f614b127e30641afc7efc462d7bbda1a7L5-R5) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L11-R12) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R16-R19) [[4]](diffhunk://#diff-94caa231f09ad77a7c9d290af8cb21544c445eb5fa535694e9a0ece6fa72235aL68-L86) [[5]](diffhunk://#diff-94caa231f09ad77a7c9d290af8cb21544c445eb5fa535694e9a0ece6fa72235aR99-R110)

**Test Runner Refactoring**
- The monolithic `CucumberTest` class has been replaced with four dedicated runner classes: `CreateEmployeeCucumberTest`, `ReadEmployeeCucumberTest`, `UpdateEmployeeCucumberTest`, and `DeleteEmployeeCucumberTest`, each targeting a specific feature file. The `testng.xml` suite has been updated to include all four runners. [[1]](diffhunk://#diff-be5228992a6c9709b5663486140eed01ef51af260921804ea6366358066726d1L11-R15) [[2]](diffhunk://#diff-e468556efeebd8fd1573692d5f7636cbcc38118aee396b5c8121a569cb578acbR1-R39) [[3]](diffhunk://#diff-85f3bc74c706cb9c5e3af960a9e3db30d8cea0184a7d7a3ea2c430fd5eb09033R1-R39) [[4]](diffhunk://#diff-a0757635656f25151d95bd7c08a6b5bd5602499935272032ca52522c9af54d5fR1-R39) [[5]](diffhunk://#diff-a871f1bb183beccc092ad51e0fde121364503102c4ab8dc2f50c65167bc02e1dL6-R9)

**Docker and CI Pipeline Enhancements**
- Docker and Docker Compose commands now run the full suite via `testng.xml` and support environment overrides through `TEST_ENV`. The Jenkins pipeline stage for running tests in Docker directly has been removed in favor of Docker Compose. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L11-R12) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R16-R19) [[3]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L23-L33)

**Documentation Updates**
- The `README.md` has been updated to clarify how to run tests in different environments using Docker or Docker Compose, and to document the new default environment and override options. Example commands and explanations for environment-specific test data have been improved. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L97-R132) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L133-R146)

**Test Data Handling**
- The method for resolving environment-specific test data paths in `TestConfig` now consistently uses the dynamically selected environment, ensuring correct data is loaded for the chosen environment.

These changes collectively make the test framework more flexible, maintainable, and easier to use across different environments and CI/CD setups.